### PR TITLE
Update to fix the 'cdn' config for Laravel 5+

### DIFF
--- a/src/config/tinymce.php
+++ b/src/config/tinymce.php
@@ -2,7 +2,7 @@
 
 return [
 
-	'cdn' => url('vendor/js/tinymce/tinymce.min.js'),
+	'cdn' => $app->runningInConsole() ? config('app.url') : url('vendor/js/tinymce/tinymce.min.js'),
 
 	'default' => [
 		"selector" => ".tinymce",


### PR DESCRIPTION
Fixed the 'cdn' url issue for Laravel 5.0+ (see issue ["Bug and Fix #8"](https://github.com/ktquez/laravel-tinymce/issues/8))